### PR TITLE
[VOL-128] CoreOS vs VolumeHub

### DIFF
--- a/catalog_client/Dockerfile
+++ b/catalog_client/Dockerfile
@@ -2,7 +2,7 @@ FROM        ubuntu:14.04.3
 
 # Last build date - this can be updated whenever there are security updates so
 # that everything is rebuilt
-ENV         security_updates_as_of 2015-11-02
+ENV         security_updates_as_of 2016-03-23
 
 # Install security updates and required packages
 RUN         apt-get -qy update && \
@@ -19,6 +19,8 @@ RUN         virtualenv /app/
 # It is really very slow to re-install the Python dependencies every time.
 # TODO: Fix this Dockerfile so we don't have to duplicate the dependencies here
 # but so that we also can cache them in an intermediate image.
+RUN         /app/bin/pip install --upgrade setuptools
+
 RUN         /app/bin/pip install \
                          'PyYAML>=3' \
                          'Twisted>=14' \

--- a/catalog_client/agents/_dockerlogs.py
+++ b/catalog_client/agents/_dockerlogs.py
@@ -116,7 +116,6 @@ class _DockerLogStream(object):
                 except:
                     write_traceback(
                         system="log-agent:docker-collector:open:failed",
-                        container=self.container_id,
                     )
                     return None
                 else:

--- a/catalog_client/agents/node_agent.py
+++ b/catalog_client/agents/node_agent.py
@@ -1,5 +1,7 @@
 # Collect Flocker version
 
+from __future__ import print_function
+
 from os import environ
 
 from twisted.internet.utils import getProcessOutput
@@ -20,4 +22,6 @@ class _Collector(object):
             env=environ,
         ).addCallback(
             lambda version: version.strip()
+        ).addErrback(
+            lambda _ : "Unknown Version"
         )


### PR DESCRIPTION
Fixes
1. Agent Logger failing when it can't find the version of Docker

Architecturally in CoreOS the previous implementation would never work - Flocker runs in a container not as an process in the os. CoreOS doesn't AFAIK support python - and I looked. 
1. Fix an error where whilst reporting an error - the VH relay would itself error
2. Update the core docker image so our changes can be seen by the world

All of the changes have been confirmed to work in my CoresOS cluster.

Note : these fixes will make logging of Eliot records an essential NOOP on CoreOS - no eliot records are forwarded on CoreOS to VH
